### PR TITLE
feat: Add Pegawai Ikatan module

### DIFF
--- a/app/Http/Controllers/Admin/PegawaiIkatanController.php
+++ b/app/Http/Controllers/Admin/PegawaiIkatanController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\PegawaiIkatanKerja; // Correct model name
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use App\Http\Requests\DataMaster\StorePegawaiIkatanRequest;
+use App\Http\Requests\DataMaster\UpdatePegawaiIkatanRequest;
+
+class PegawaiIkatanController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $query = PegawaiIkatanKerja::orderBy('nama');
+
+        if ($request->has('search')) {
+            $query->where('nama', 'like', '%' . $request->search . '%');
+        }
+
+        $pegawaiIkatans = $query->paginate($request->get('per_page', 10));
+
+        return Inertia::render('Admin/PegawaiIkatan/Index', [
+            'pegawaiIkatans' => $pegawaiIkatans,
+            'filters' => $request->only(['search']),
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StorePegawaiIkatanRequest $request)
+    {
+        PegawaiIkatanKerja::create($request->validated());
+
+        return redirect()->route('data-master.pegawai-ikatan.index')->with('success', 'Pegawai Ikatan created successfully.');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdatePegawaiIkatanRequest $request, PegawaiIkatanKerja $pegawaiIkatan)
+    {
+        $pegawaiIkatan->update($request->validated());
+
+        return redirect()->route('data-master.pegawai-ikatan.index')->with('success', 'Pegawai Ikatan updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(PegawaiIkatanKerja $pegawaiIkatan)
+    {
+        // Add any checks if necessary, e.g., if it's linked to other models
+        // For example:
+        // if ($pegawaiIkatan->pegawai()->exists()) {
+        //     return redirect()->route('data-master.pegawai-ikatan.index')->with('error', 'Pegawai Ikatan cannot be deleted because it is in use.');
+        // }
+        $pegawaiIkatan->delete();
+
+        return redirect()->route('data-master.pegawai-ikatan.index')->with('success', 'Pegawai Ikatan deleted successfully.');
+    }
+}

--- a/app/Http/Requests/DataMaster/StorePegawaiIkatanRequest.php
+++ b/app/Http/Requests/DataMaster/StorePegawaiIkatanRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\DataMaster;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class StorePegawaiIkatanRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // Replace with your actual authorization logic, e.g., Gate::allows('manage_datamaster')
+        return true; // Assuming authorization is handled elsewhere or not strictly needed for this example
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'nama' => 'required|string|max:255|unique:pegawai_ikatans,nama',
+        ];
+    }
+}

--- a/app/Http/Requests/DataMaster/UpdatePegawaiIkatanRequest.php
+++ b/app/Http/Requests/DataMaster/UpdatePegawaiIkatanRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\DataMaster;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+use App\Models\PegawaiIkatanKerja; // Import the model
+
+class UpdatePegawaiIkatanRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // Replace with your actual authorization logic, e.g., Gate::allows('manage_datamaster')
+        return true; // Assuming authorization is handled elsewhere or not strictly needed for this example
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $pegawaiIkatanId = $this->route('pegawai_ikatan') instanceof PegawaiIkatanKerja ? $this->route('pegawai_ikatan')->id : $this->route('pegawai_ikatan');
+        return [
+            'nama' => 'required|string|max:255|unique:pegawai_ikatans,nama,' . $pegawaiIkatanId,
+        ];
+    }
+}

--- a/app/Models/PegawaiIkatanKerja.php
+++ b/app/Models/PegawaiIkatanKerja.php
@@ -9,4 +9,8 @@ class PegawaiIkatanKerja extends Model
 {
     /** @use HasFactory<\Database\Factories\PegawaiIkatanKerjaFactory> */
     use HasFactory;
+
+    protected $fillable = ['nama']; // Added fillable property
+
+    protected $table = 'pegawai_ikatans'; // Ensuring correct table name
 }

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -41,6 +41,11 @@ const mainNavGroups: NavGroup[] = [
                 href: route('data-master.units.index'),
                 icon: Database, // Using Database icon for Units
             },
+            {
+                title: 'Pegawai Ikatan', // Added
+                href: route('data-master.pegawai-ikatan.index'), // Added
+                icon: Database, // Using Database icon for now, can be changed
+            },
         ],
     },
 ];

--- a/resources/js/pages/Admin/PegawaiIkatan/Index.tsx
+++ b/resources/js/pages/Admin/PegawaiIkatan/Index.tsx
@@ -1,0 +1,227 @@
+import { Pagination } from '@/components/pagination';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import AppLayout from '@/layouts/app-layout';
+import { PaginatedResponse, PegawaiIkatan } from '@/types'; // Added PegawaiIkatan
+import { Head, router, useForm } from '@inertiajs/react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Pencil, PlusCircle, Trash2 } from 'lucide-react';
+
+interface PegawaiIkatanIndexProps {
+    pegawaiIkatans: PaginatedResponse<PegawaiIkatan>; // Changed from units
+    filters: { search?: string };
+}
+
+export default function PegawaiIkatanIndexPage({ pegawaiIkatans, filters }: PegawaiIkatanIndexProps) {
+    const [searchTerm, setSearchTerm] = useState(filters.search || '');
+    const [isCreateModalOpen, setCreateModalOpen] = useState(false);
+    const [isEditModalOpen, setEditModalOpen] = useState(false);
+    const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
+    const [currentPegawaiIkatan, setCurrentPegawaiIkatan] = useState<PegawaiIkatan | null>(null); // Changed from currentUnit
+
+    const { data, setData, post, put, delete: destroy, processing, errors, reset } = useForm({
+        nama: '', // Changed from unit fields
+    });
+
+    const handleSearch = () => {
+        router.get(route('data-master.pegawai-ikatan.index'), { search: searchTerm }, { preserveState: true }); // Changed route
+    };
+
+    const openCreateModal = () => {
+        reset();
+        setCreateModalOpen(true);
+    };
+
+    const openEditModal = (pegawaiIkatan: PegawaiIkatan) => { // Changed from unit
+        setCurrentPegawaiIkatan(pegawaiIkatan); // Changed from setCurrentUnit
+        setData({
+            nama: pegawaiIkatan.nama, // Changed from unit fields
+        });
+        setEditModalOpen(true);
+    };
+
+    const openDeleteModal = (pegawaiIkatan: PegawaiIkatan) => { // Changed from unit
+        setCurrentPegawaiIkatan(pegawaiIkatan); // Changed from setCurrentUnit
+        setDeleteModalOpen(true);
+    };
+
+    const handleCreate = (e: React.FormEvent) => {
+        e.preventDefault();
+        post(route('data-master.pegawai-ikatan.store'), { // Changed route
+            onSuccess: () => {
+                setCreateModalOpen(false);
+                toast.success('Pegawai Ikatan created successfully.'); // Changed message
+            },
+            onError: (pageErrors) => {
+                if (pageErrors.nama) {
+                    toast.error(pageErrors.nama);
+                } else {
+                    toast.error('Failed to create Pegawai Ikatan.'); // Changed message
+                }
+            },
+        });
+    };
+
+    const handleUpdate = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (currentPegawaiIkatan) {
+            put(route('data-master.pegawai-ikatan.update', currentPegawaiIkatan.id), { // Changed route
+                onSuccess: () => {
+                    setEditModalOpen(false);
+                    toast.success('Pegawai Ikatan updated successfully.'); // Changed message
+                },
+                onError: (pageErrors) => {
+                    if (pageErrors.nama) {
+                        toast.error(pageErrors.nama);
+                    } else {
+                        toast.error('Failed to update Pegawai Ikatan.'); // Changed message
+                    }
+                },
+            });
+        }
+    };
+
+    const handleDelete = () => {
+        if (currentPegawaiIkatan) {
+            destroy(route('data-master.pegawai-ikatan.destroy', currentPegawaiIkatan.id), { // Changed route
+                onSuccess: () => {
+                    setDeleteModalOpen(false);
+                    toast.success('Pegawai Ikatan deleted successfully.'); // Changed message
+                },
+                onError: (pageErrors: any) => { // Added type for pageErrors
+                    if (pageErrors && pageErrors.error) {
+                        toast.error(pageErrors.error);
+                    } else {
+                        toast.error('Failed to delete Pegawai Ikatan.'); // Changed message
+                    }
+                },
+            });
+        }
+    };
+
+    return (
+        <AppLayout>
+            <Head title="Pegawai Ikatan" /> {/* Changed title */}
+
+            <div className="py-12">
+                <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                    <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
+                        <div className="p-6 text-gray-900 dark:text-gray-100">
+                            <div className="mb-4 flex items-center">
+                                <Input
+                                    type="text"
+                                    placeholder="Search pegawai ikatan..." // Changed placeholder
+                                    value={searchTerm}
+                                    onChange={(e) => setSearchTerm(e.target.value)}
+                                    onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
+                                    className="mr-2 max-w-sm"
+                                />
+                                <Button onClick={handleSearch}>Search</Button>
+                            </div>
+
+                            <div className="mb-4 flex justify-end">
+                                <Button onClick={openCreateModal}>
+                                    <PlusCircle className="mr-2 h-4 w-4" />
+                                    New Pegawai Ikatan {/* Changed button text */}
+                                </Button>
+                            </div>
+
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Nama</TableHead> {/* Changed table header */}
+                                        <TableHead className="text-right">Actions</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {pegawaiIkatans.data.map((pegawaiIkatan) => ( // Changed variable name
+                                        <TableRow key={pegawaiIkatan.id}>
+                                            <TableCell>{pegawaiIkatan.nama}</TableCell> {/* Changed data field */}
+                                            <TableCell className="text-right">
+                                                <Button variant="outline" size="sm" onClick={() => openEditModal(pegawaiIkatan)} className="mr-2"> {/* Changed handler */}
+                                                    <Pencil className="mr-1 h-4 w-4" />
+                                                    Edit
+                                                </Button>
+                                                <Button variant="destructive" size="sm" onClick={() => openDeleteModal(pegawaiIkatan)}> {/* Changed handler */}
+                                                    <Trash2 className="mr-1 h-4 w-4" />
+                                                    Delete
+                                                </Button>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                            <Pagination className="mt-6" links={pegawaiIkatans.links} /> {/* Changed variable name */}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* Create/Edit Dialog */}
+            <Dialog open={isCreateModalOpen || isEditModalOpen} onOpenChange={isCreateModalOpen ? setCreateModalOpen : setEditModalOpen}>
+                <DialogContent className="sm:max-w-[425px]">
+                    <DialogHeader>
+                        <DialogTitle>{isCreateModalOpen ? 'Create Pegawai Ikatan' : 'Edit Pegawai Ikatan'}</DialogTitle> {/* Changed title */}
+                        <DialogDescription>
+                            {isCreateModalOpen ? 'Add a new pegawai ikatan to the system.' : 'Update the details of the pegawai ikatan.'} {/* Changed description */}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <form onSubmit={isCreateModalOpen ? handleCreate : handleUpdate}>
+                        <div className="grid gap-4 py-4">
+                            <div className="grid grid-cols-4 items-center gap-4">
+                                <Label htmlFor="nama" className="text-right"> {/* Changed label */}
+                                    Nama
+                                </Label>
+                                <Input id="nama" value={data.nama} onChange={(e) => setData('nama', e.target.value)} className="col-span-3" /> {/* Changed field */}
+                                {errors.nama && <p className="col-span-4 text-sm text-red-600">{errors.nama}</p>}
+                            </div>
+                        </div>
+                        <DialogFooter>
+                            <DialogClose asChild>
+                                <Button type="button" variant="outline">
+                                    Cancel
+                                </Button>
+                            </DialogClose>
+                            <Button type="submit" disabled={processing}>
+                                {processing ? 'Saving...' : 'Save'}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+
+            {/* Delete Confirmation Dialog */}
+            <Dialog open={isDeleteModalOpen} onOpenChange={setDeleteModalOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Are you sure?</DialogTitle>
+                        <DialogDescription>
+                            This action cannot be undone. This will permanently delete the pegawai ikatan:{' '} {/* Changed description */}
+                            <span className="font-semibold">{currentPegawaiIkatan?.nama}</span>. {/* Changed variable */}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <DialogClose asChild>
+                            <Button variant="outline">Cancel</Button>
+                        </DialogClose>
+                        <Button variant="destructive" onClick={handleDelete} disabled={processing}>
+                            {processing ? 'Deleting...' : 'Delete'}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -81,3 +81,10 @@ export interface SelectOption {
     value: string;
     label: string;
 }
+
+export interface PegawaiIkatan { // Added PegawaiIkatan type
+    id: number;
+    nama: string;
+    created_at: string;
+    updated_at: string;
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Admin\PermissionController;
 use App\Http\Controllers\Admin\RoleController;
 use App\Http\Controllers\Admin\UnitController;
+use App\Http\Controllers\Admin\PegawaiIkatanController; // Added
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -23,6 +24,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // TEMPORARILY REMOVED: ->middleware('permission:manage_datamaster') due to test environment issues
     Route::name('data-master.')->prefix('data-master')->group(function () {
         Route::resource('units', UnitController::class)->except(['show', 'create', 'edit']);
+        Route::resource('pegawai-ikatan', PegawaiIkatanController::class)->except(['show', 'create', 'edit']); // Added
     });
 });
 


### PR DESCRIPTION
- Create PegawaiIkatanController with CRUD operations.
- Add routes for pegawai-ikatan.
- Update PegawaiIkatanKerja model with fillable property and table name.
- Create StorePegawaiIkatanRequest and UpdatePegawaiIkatanRequest for validation.
- Create Index.tsx page for Pegawai Ikatan with table, search, and CRUD modals.
- Add PegawaiIkatan type to TypeScript definitions.
- Add navigation link for Pegawai Ikatan in the sidebar.