### PR TITLE
feat: Add Periode Management

### DIFF
--- a/app/Http/Controllers/Admin/PeriodeController.php
+++ b/app/Http/Controllers/Admin/PeriodeController.php
@@ -3,8 +3,178 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Periode;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
 
 class PeriodeController extends Controller
 {
-    //
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $periodes = Periode::query()
+            ->orderBy('tahun', 'desc')
+            ->orderBy('periode', 'desc')
+            ->paginate(15)
+            ->withQueryString();
+
+        return Inertia::render('Admin/Periodes/Index', [
+            'periodes' => $periodes,
+            'filters' => $request->all(['search', 'trashed']), // Example, adjust if filters are added
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return Inertia::render('Admin/Periodes/Create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $validatedData = $request->validate([
+            'nama' => 'required|string|max:255',
+            'tahun' => 'required|integer|digits:4',
+            'periode' => 'required|integer',
+            'keterangan' => 'nullable|string',
+            'pir' => 'nullable|numeric',
+            'tgl_mulai' => 'nullable|date',
+            'tgl_selesai' => 'nullable|date',
+            'tgl_input_mulai' => 'nullable|date',
+            'tgl_input_selesai' => 'nullable|date',
+            'tgl_verifikasi_mulai' => 'nullable|date',
+            'tgl_verifikasi_selesai' => 'nullable|date',
+            'tgl_validasi_mulai' => 'nullable|date',
+            'tgl_validasi_selesai' => 'nullable|date',
+            'kehadiran' => 'nullable|integer',
+            'skp' => 'nullable|integer',
+            'format_skp' => 'nullable|integer',
+            'calc_method' => 'nullable|integer',
+            'bkd_tahun' => 'nullable|integer|digits:4',
+            'bkd_semester' => 'nullable|string|max:255',
+            'bkd_source_p1' => 'nullable|integer',
+            'bkd_tahun_p1' => 'nullable|integer|digits:4',
+            'bkd_semester_p1' => 'nullable|string|max:255',
+            'bkd_source_p2' => 'nullable|integer',
+            'bkd_tahun_p2' => 'nullable|integer|digits:4',
+            'bkd_semester_p2' => 'nullable|string|max:255',
+            'aktif' => 'sometimes|boolean', // usually handled by activate/deactivate
+            'show_insentif' => 'sometimes|boolean',
+            'user_confirmation' => 'sometimes|boolean',
+        ]);
+
+        // If 'aktif' is being set directly, ensure it's a boolean 0 or 1
+        if ($request->has('aktif')) {
+            $validatedData['aktif'] = filter_var($request->aktif, FILTER_VALIDATE_BOOLEAN);
+        }
+
+        // Default 'aktif' to 0 if not provided, as activation is a separate step
+        $validatedData['aktif'] = $validatedData['aktif'] ?? 0;
+
+        Periode::create($validatedData);
+
+        return redirect()->route('admin.periodes.index')->with('success', 'Periode berhasil ditambahkan.');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Periode $periode)
+    {
+        return Inertia::render('Admin/Periodes/Edit', [
+            'periode' => $periode,
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Periode $periode)
+    {
+        $validatedData = $request->validate([
+            'nama' => 'required|string|max:255',
+            'tahun' => 'required|integer|digits:4',
+            'periode' => 'required|integer',
+            'keterangan' => 'nullable|string',
+            'pir' => 'nullable|numeric',
+            'tgl_mulai' => 'nullable|date',
+            'tgl_selesai' => 'nullable|date',
+            'tgl_input_mulai' => 'nullable|date',
+            'tgl_input_selesai' => 'nullable|date',
+            'tgl_verifikasi_mulai' => 'nullable|date',
+            'tgl_verifikasi_selesai' => 'nullable|date',
+            'tgl_validasi_mulai' => 'nullable|date',
+            'tgl_validasi_selesai' => 'nullable|date',
+            'kehadiran' => 'nullable|integer',
+            'skp' => 'nullable|integer',
+            'format_skp' => 'nullable|integer',
+            'calc_method' => 'nullable|integer',
+            'bkd_tahun' => 'nullable|integer|digits:4',
+            'bkd_semester' => 'nullable|string|max:255',
+            'bkd_source_p1' => 'nullable|integer',
+            'bkd_tahun_p1' => 'nullable|integer|digits:4',
+            'bkd_semester_p1' => 'nullable|string|max:255',
+            'bkd_source_p2' => 'nullable|integer',
+            'bkd_tahun_p2' => 'nullable|integer|digits:4',
+            'bkd_semester_p2' => 'nullable|string|max:255',
+            // 'aktif' is generally not updated directly here, but via activate/deactivate
+            'show_insentif' => 'sometimes|boolean',
+            'user_confirmation' => 'sometimes|boolean',
+        ]);
+
+        if ($request->has('show_insentif')) {
+            $validatedData['show_insentif'] = filter_var($request->show_insentif, FILTER_VALIDATE_BOOLEAN);
+        }
+        if ($request->has('user_confirmation')) {
+            $validatedData['user_confirmation'] = filter_var($request->user_confirmation, FILTER_VALIDATE_BOOLEAN);
+        }
+
+        $periode->update($validatedData);
+
+        return redirect()->route('admin.periodes.index')->with('success', 'Periode berhasil diperbarui.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Periode $periode)
+    {
+        if ($periode->aktif) {
+            return redirect()->route('admin.periodes.index')->with('error', 'Periode aktif tidak dapat dihapus.');
+        }
+        $periode->delete();
+
+        return redirect()->route('admin.periodes.index')->with('success', 'Periode berhasil dihapus.');
+    }
+
+    /**
+     * Activate the specified periode.
+     */
+    public function activate(Request $request, Periode $periode)
+    {
+        DB::transaction(function () use ($periode) {
+            Periode::where('id', '!=', $periode->id)->update(['aktif' => 0]);
+            $periode->update(['aktif' => 1]);
+        });
+
+        return redirect()->route('admin.periodes.index')->with('success', "Periode {$periode->nama} berhasil diaktifkan.");
+    }
+
+    /**
+     * Deactivate the specified periode.
+     */
+    public function deactivate(Request $request, Periode $periode)
+    {
+        $periode->update(['aktif' => 0]);
+
+        return redirect()->route('admin.periodes.index')->with('success', "Periode {$periode->nama} berhasil dinonaktifkan.");
+    }
 }

--- a/app/Models/Periode.php
+++ b/app/Models/Periode.php
@@ -9,4 +9,35 @@ class Periode extends Model
 {
     /** @use HasFactory<\Database\Factories\PeriodeFactory> */
     use HasFactory;
+
+    protected $fillable = [
+        'tahun',
+        'periode',
+        'nama',
+        'keterangan',
+        'pir',
+        'tgl_mulai',
+        'tgl_selesai',
+        'tgl_input_mulai',
+        'tgl_input_selesai',
+        'tgl_verifikasi_mulai',
+        'tgl_verifikasi_selesai',
+        'tgl_validasi_mulai',
+        'tgl_validasi_selesai',
+        'kehadiran',
+        'skp',
+        'format_skp',
+        'calc_method',
+        'bkd_tahun',
+        'bkd_semester',
+        'bkd_source_p1',
+        'bkd_tahun_p1',
+        'bkd_semester_p1',
+        'bkd_source_p2',
+        'bkd_tahun_p2',
+        'bkd_semester_p2',
+        'aktif',
+        'show_insentif',
+        'user_confirmation',
+    ];
 }

--- a/resources/js/Pages/Admin/Periodes/Create.tsx
+++ b/resources/js/Pages/Admin/Periodes/Create.tsx
@@ -1,0 +1,18 @@
+import AppLayout from '@/layouts/app-layout'; // Assuming AppLayout exists
+import PeriodeForm from './Partials/PeriodeForm';
+import { Head } from '@inertiajs/react';
+import { PageProps } from '@/types'; // Assuming PageProps for auth, etc.
+
+export default function CreatePeriodePage({ auth }: PageProps) {
+    return (
+        <AppLayout user={auth.user} header="Periode Management">
+            <Head title="Tambah Periode Baru" />
+
+            <div className="py-6 md:py-12">
+                <div className="max-w-3xl mx-auto sm:px-6 lg:px-8">
+                    <PeriodeForm mode="create" />
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Periodes/Edit.tsx
+++ b/resources/js/Pages/Admin/Periodes/Edit.tsx
@@ -1,0 +1,23 @@
+import AppLayout from '@/layouts/app-layout'; // Assuming AppLayout exists
+import PeriodeForm from './Partials/PeriodeForm';
+import { Head } from '@inertiajs/react';
+import { PageProps } from '@/types';
+import { Periode } from '@/types/periode'; // Assuming Periode type
+
+interface EditPeriodePageProps extends PageProps {
+    periode: Periode;
+}
+
+export default function EditPeriodePage({ auth, periode }: EditPeriodePageProps) {
+    return (
+        <AppLayout user={auth.user} header="Periode Management">
+            <Head title={`Edit Periode - ${periode.nama}`} />
+
+            <div className="py-6 md:py-12">
+                <div className="max-w-3xl mx-auto sm:px-6 lg:px-8">
+                    <PeriodeForm mode="edit" periode={periode} />
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Periodes/Index.tsx
+++ b/resources/js/Pages/Admin/Periodes/Index.tsx
@@ -1,0 +1,194 @@
+import AppLayout from '@/layouts/app-layout';
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import { PageProps } from '@/types';
+import { Periode, PeriodesIndexProps } from '@/types/periode';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { IconEdit, IconPlus, IconTrash, IconCheck, IconX } from '@tabler/icons-react'; // Assuming Tabler icons are used
+import Pagination from '@/components/pagination'; // Assuming Pagination component exists
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import React, { useState, useEffect } from 'react';
+import { toast } from 'sonner'; // Assuming sonner for toast notifications
+
+export default function IndexPeriodePage({ auth, periodes: periodesPaginator, flash }: PageProps<PeriodesIndexProps>) {
+    const { props } = usePage<PageProps<PeriodesIndexProps>>();
+    const [showDeleteAlert, setShowDeleteAlert] = useState(false);
+    const [periodeToDelete, setPeriodeToDelete] = useState<Periode | null>(null);
+
+    useEffect(() => {
+        if (props.flash?.success) {
+            toast.success(props.flash.success);
+        }
+        if (props.flash?.error) {
+            toast.error(props.flash.error);
+        }
+    }, [props.flash]);
+
+
+    const handleDeletePeriode = () => {
+        if (periodeToDelete) {
+            router.delete(route('admin.periodes.destroy', periodeToDelete.id), {
+                onSuccess: () => {
+                    toast.success(`Periode "${periodeToDelete.nama}" berhasil dihapus.`);
+                    setShowDeleteAlert(false);
+                    setPeriodeToDelete(null);
+                },
+                onError: (errors) => {
+                    const errorMessages = Object.values(errors).join(', ');
+                    toast.error(errorMessages || `Gagal menghapus periode "${periodeToDelete.nama}".`);
+                    setShowDeleteAlert(false);
+                }
+            });
+        }
+    };
+
+    const openDeleteAlert = (periode: Periode) => {
+        if (periode.aktif) {
+            toast.error("Periode yang sedang aktif tidak dapat dihapus.");
+            return;
+        }
+        setPeriodeToDelete(periode);
+        setShowDeleteAlert(true);
+    };
+
+    const handleActivate = (periode: Periode) => {
+        router.post(route('admin.periodes.activate', periode.id), {}, {
+            onSuccess: () => toast.success(`Periode "${periode.nama}" berhasil diaktifkan.`),
+            onError: (errors) => toast.error(Object.values(errors).join(', ') || `Gagal mengaktifkan periode.`),
+        });
+    };
+
+    const handleDeactivate = (periode: Periode) => {
+        router.post(route('admin.periodes.deactivate', periode.id), {}, {
+            onSuccess: () => toast.success(`Periode "${periode.nama}" berhasil dinonaktifkan.`),
+            onError: (errors) => toast.error(Object.values(errors).join(', ') || `Gagal menonaktifkan periode.`),
+        });
+    };
+
+    const { data: periodes, links } = periodesPaginator;
+
+    return (
+        <AppLayout user={auth.user} header="Manajemen Periode">
+            <Head title="Daftar Periode" />
+
+            <div className="py-6 md:py-12">
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    <div className="flex justify-between items-center mb-6">
+                        <h2 className="text-2xl font-semibold">Daftar Periode</h2>
+                        <Button asChild>
+                            <Link href={route('admin.periodes.create')}>
+                                <IconPlus className="mr-2 h-4 w-4" /> Tambah Periode Baru
+                            </Link>
+                        </Button>
+                    </div>
+
+                    <div className="bg-white shadow-sm sm:rounded-lg">
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Nama Periode</TableHead>
+                                    <TableHead className="text-center">Tahun</TableHead>
+                                    <TableHead className="text-center">Periode</TableHead>
+                                    <TableHead>Status</TableHead>
+                                    <TableHead>Tgl Mulai</TableHead>
+                                    <TableHead>Tgl Selesai</TableHead>
+                                    <TableHead className="text-right">Aksi</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {periodes.length > 0 ? (
+                                    periodes.map((periode) => (
+                                        <TableRow key={periode.id}>
+                                            <TableCell className="font-medium">{periode.nama}</TableCell>
+                                            <TableCell className="text-center">{periode.tahun}</TableCell>
+                                            <TableCell className="text-center">{periode.periode}</TableCell>
+                                            <TableCell>
+                                                {periode.aktif ? (
+                                                    <Badge variant="default" className="bg-green-500 hover:bg-green-600">Aktif</Badge>
+                                                ) : (
+                                                    <Badge variant="outline">Tidak Aktif</Badge>
+                                                )}
+                                            </TableCell>
+                                            <TableCell>{periode.tgl_mulai ? new Date(periode.tgl_mulai).toLocaleDateString('id-ID') : '-'}</TableCell>
+                                            <TableCell>{periode.tgl_selesai ? new Date(periode.tgl_selesai).toLocaleDateString('id-ID') : '-'}</TableCell>
+                                            <TableCell className="text-right space-x-2">
+                                                {periode.aktif ? (
+                                                    <Button variant="outline" size="sm" onClick={() => handleDeactivate(periode)}>
+                                                        <IconX className="mr-1 h-4 w-4" /> Nonaktifkan
+                                                    </Button>
+                                                ) : (
+                                                    <Button variant="default" size="sm" onClick={() => handleActivate(periode)} className="bg-blue-500 hover:bg-blue-600">
+                                                        <IconCheck className="mr-1 h-4 w-4" /> Aktifkan
+                                                    </Button>
+                                                )}
+                                                <Button variant="outline" size="icon" asChild>
+                                                    <Link href={route('admin.periodes.edit', periode.id)}>
+                                                        <IconEdit className="h-4 w-4" />
+                                                        <span className="sr-only">Edit</span>
+                                                    </Link>
+                                                </Button>
+                                                <Button
+                                                    variant="destructive"
+                                                    size="icon"
+                                                    onClick={() => openDeleteAlert(periode)}
+                                                    disabled={!!periode.aktif} // Disable if active
+                                                >
+                                                    <IconTrash className="h-4 w-4" />
+                                                    <span className="sr-only">Hapus</span>
+                                                </Button>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))
+                                ) : (
+                                    <TableRow>
+                                        <TableCell colSpan={7} className="text-center">
+                                            Tidak ada data periode.
+                                        </TableCell>
+                                    </TableRow>
+                                )}
+                            </TableBody>
+                        </Table>
+                    </div>
+                    {links && <Pagination links={links} className="mt-6" />}
+                </div>
+            </div>
+
+            <AlertDialog open={showDeleteAlert} onOpenChange={setShowDeleteAlert}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Apakah Anda yakin?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Tindakan ini tidak dapat dibatalkan. Ini akan menghapus periode
+                            <span className="font-semibold"> {periodeToDelete?.nama} </span> secara permanen.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel onClick={() => setPeriodeToDelete(null)}>Batal</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleDeletePeriode} className="bg-red-600 hover:bg-red-700">
+                            Ya, Hapus
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+        </AppLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Periodes/Partials/PeriodeForm.tsx
+++ b/resources/js/Pages/Admin/Periodes/Partials/PeriodeForm.tsx
@@ -1,0 +1,234 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Periode } from '@/types/periode'; // Assuming type definition exists or will be created
+import { Link, useForm } from '@inertiajs/react';
+import InputError from '@/components/input-error'; // Assuming this component exists
+import React from 'react';
+
+interface PeriodeFormProps {
+    periode?: Periode; // Optional: for editing
+    mode: 'create' | 'edit';
+}
+
+// Define a type for the form data based on Periode, making all fields potentially partial for the form
+type PeriodeFormData = Partial<Omit<Periode, 'id' | 'created_at' | 'updated_at'>> & {
+    nama: string;
+    tahun: number;
+    periode: number;
+    // Add other required or frequently used fields here, others can be string | number | undefined
+    keterangan?: string;
+    tgl_mulai?: string; // Dates will be strings from form inputs
+    tgl_selesai?: string;
+    // Add other fields as needed from the model's fillable array
+    pir?: number;
+    tgl_input_mulai?: string;
+    tgl_input_selesai?: string;
+    tgl_verifikasi_mulai?: string;
+    tgl_verifikasi_selesai?: string;
+    tgl_validasi_mulai?: string;
+    tgl_validasi_selesai?: string;
+    kehadiran?: number;
+    skp?: number;
+    format_skp?: number;
+    calc_method?: number;
+    bkd_tahun?: number;
+    bkd_semester?: string;
+    bkd_source_p1?: number;
+    bkd_tahun_p1?: number;
+    bkd_semester_p1?: string;
+    bkd_source_p2?: number;
+    bkd_tahun_p2?: number;
+    bkd_semester_p2?: string;
+    show_insentif?: boolean;
+    user_confirmation?: boolean;
+};
+
+export default function PeriodeForm({ periode, mode }: PeriodeFormProps) {
+    const { data, setData, post, put, processing, errors, reset } = useForm<PeriodeFormData>({
+        nama: periode?.nama || '',
+        tahun: periode?.tahun || new Date().getFullYear(),
+        periode: periode?.periode || 1,
+        keterangan: periode?.keterangan || '',
+        tgl_mulai: periode?.tgl_mulai || '',
+        tgl_selesai: periode?.tgl_selesai || '',
+        pir: periode?.pir ?? 3000, // Default from migration
+        tgl_input_mulai: periode?.tgl_input_mulai || '',
+        tgl_input_selesai: periode?.tgl_input_selesai || '',
+        tgl_verifikasi_mulai: periode?.tgl_verifikasi_mulai || '',
+        tgl_verifikasi_selesai: periode?.tgl_verifikasi_selesai || '',
+        tgl_validasi_mulai: periode?.tgl_validasi_mulai || '',
+        tgl_validasi_selesai: periode?.tgl_validasi_selesai || '',
+        kehadiran: periode?.kehadiran ?? undefined,
+        skp: periode?.skp ?? undefined,
+        format_skp: periode?.format_skp ?? undefined,
+        calc_method: periode?.calc_method ?? undefined,
+        bkd_tahun: periode?.bkd_tahun ?? undefined,
+        bkd_semester: periode?.bkd_semester || '',
+        bkd_source_p1: periode?.bkd_source_p1 ?? undefined,
+        bkd_tahun_p1: periode?.bkd_tahun_p1 ?? undefined,
+        bkd_semester_p1: periode?.bkd_semester_p1 || '',
+        bkd_source_p2: periode?.bkd_source_p2 ?? undefined,
+        bkd_tahun_p2: periode?.bkd_tahun_p2 ?? undefined,
+        bkd_semester_p2: periode?.bkd_semester_p2 || '',
+        show_insentif: periode?.show_insentif ?? false,
+        user_confirmation: periode?.user_confirmation ?? true, // Default from migration
+    });
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        if (mode === 'create') {
+            post(route('admin.periodes.store'), {
+                onSuccess: () => reset(),
+            });
+        } else if (periode) {
+            put(route('admin.periodes.update', periode.id),{
+                onSuccess: () => reset(),
+            });
+        }
+    };
+
+    // Helper to simplify input change handling
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        const { name, value, type } = e.target;
+        let processedValue: string | number | boolean = value;
+
+        if (type === 'number') {
+            processedValue = value === '' ? '' : Number(value);
+        } else if (type === 'checkbox') {
+            processedValue = (e.target as HTMLInputElement).checked;
+        }
+        setData(name as keyof PeriodeFormData, processedValue as any); // Use 'as any' carefully
+    };
+
+    const handleCheckboxChange = (name: keyof PeriodeFormData) => (checked: boolean) => {
+        setData(name, checked);
+    };
+
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>{mode === 'create' ? 'Tambah Periode Baru' : 'Edit Periode'}</CardTitle>
+                <CardDescription>
+                    {mode === 'create' ? 'Isi detail untuk periode baru.' : 'Ubah detail periode yang sudah ada.'}
+                </CardDescription>
+            </CardHeader>
+            <form onSubmit={handleSubmit}>
+                <CardContent className="space-y-4">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <Label htmlFor="nama">Nama Periode</Label>
+                            <Input
+                                id="nama"
+                                name="nama"
+                                value={data.nama}
+                                onChange={handleInputChange}
+                                className="mt-1 block w-full"
+                                required
+                            />
+                            <InputError message={errors.nama} className="mt-2" />
+                        </div>
+                        <div>
+                            <Label htmlFor="tahun">Tahun</Label>
+                            <Input
+                                id="tahun"
+                                name="tahun"
+                                type="number"
+                                value={data.tahun}
+                                onChange={handleInputChange}
+                                className="mt-1 block w-full"
+                                required
+                            />
+                            <InputError message={errors.tahun} className="mt-2" />
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <Label htmlFor="periode">Periode (Angka)</Label>
+                            <Input
+                                id="periode"
+                                name="periode"
+                                type="number"
+                                value={data.periode}
+                                onChange={handleInputChange}
+                                className="mt-1 block w-full"
+                                required
+                            />
+                            <InputError message={errors.periode} className="mt-2" />
+                        </div>
+                        <div>
+                            <Label htmlFor="keterangan">Keterangan</Label>
+                            <Textarea
+                                id="keterangan"
+                                name="keterangan"
+                                value={data.keterangan || ''}
+                                onChange={handleInputChange}
+                                className="mt-1 block w-full"
+                            />
+                            <InputError message={errors.keterangan} className="mt-2" />
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <Label htmlFor="tgl_mulai">Tanggal Mulai</Label>
+                            <Input
+                                id="tgl_mulai"
+                                name="tgl_mulai"
+                                type="date"
+                                value={data.tgl_mulai || ''}
+                                onChange={handleInputChange}
+                                className="mt-1 block w-full"
+                            />
+                            <InputError message={errors.tgl_mulai} className="mt-2" />
+                        </div>
+                        <div>
+                            <Label htmlFor="tgl_selesai">Tanggal Selesai</Label>
+                            <Input
+                                id="tgl_selesai"
+                                name="tgl_selesai"
+                                type="date"
+                                value={data.tgl_selesai || ''}
+                                onChange={handleInputChange}
+                                className="mt-1 block w-full"
+                            />
+                            <InputError message={errors.tgl_selesai} className="mt-2" />
+                        </div>
+                    </div>
+
+                    {/* Optional: Add more fields here as needed, example for PIR */}
+                    <div>
+                        <Label htmlFor="pir">PIR</Label>
+                        <Input
+                            id="pir"
+                            name="pir"
+                            type="number"
+                            value={data.pir ?? ''}
+                            onChange={handleInputChange}
+                            className="mt-1 block w-full"
+                        />
+                        <InputError message={errors.pir} className="mt-2" />
+                    </div>
+
+
+                    {/* Add other fields tgl_input_mulai, tgl_input_selesai etc. similarly if they need to be on the main form */}
+                    {/* For boolean fields like show_insentif, user_confirmation, use Checkbox from shadcn if available */}
+                    {/* This example keeps the form concise with core fields. */}
+
+                </CardContent>
+                <CardFooter className="flex justify-between">
+                    <Button type="button" variant="outline" asChild>
+                        <Link href={route('admin.periodes.index')}>Batal</Link>
+                    </Button>
+                    <Button type="submit" disabled={processing}>
+                        {processing ? (mode === 'create' ? 'Menyimpan...' : 'Memperbarui...') : (mode === 'create' ? 'Simpan' : 'Update')}
+                    </Button>
+                </CardFooter>
+            </form>
+        </Card>
+    );
+}

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -89,6 +89,12 @@ const mainNavGroups: NavGroup[] = [
                 href: route('admin.rubrik.index'),
                 icon: Database, // You might want to choose a more specific icon
             },
+            {
+                title: 'Periode',
+                href: route('admin.periodes.index'),
+                icon: Database, // Using Database icon for now
+                // permission: 'periode.manage' // Optional: Add permission if needed
+            },
         ],
     },
 ];

--- a/resources/js/types/periode.d.ts
+++ b/resources/js/types/periode.d.ts
@@ -1,0 +1,44 @@
+import { LaravelPaginatorProps } from './index'; // Assuming this general type exists for paginator props
+
+export interface Periode {
+    id: number;
+    tahun: number;
+    periode: number;
+    nama: string;
+    keterangan?: string;
+    pir?: number;
+    tgl_mulai?: string; // Dates are strings
+    tgl_selesai?: string;
+    tgl_input_mulai?: string;
+    tgl_input_selesai?: string;
+    tgl_verifikasi_mulai?: string;
+    tgl_verifikasi_selesai?: string;
+    tgl_validasi_mulai?: string;
+    tgl_validasi_selesai?: string;
+    kehadiran?: number;
+    skp?: number;
+    format_skp?: number;
+    calc_method?: number;
+    bkd_tahun?: number;
+    bkd_semester?: string;
+    bkd_source_p1?: number;
+    bkd_tahun_p1?: number;
+    bkd_semester_p1?: string;
+    bkd_source_p2?: number;
+    bkd_tahun_p2?: number;
+    bkd_semester_p2?: string;
+    aktif: 0 | 1 | boolean; // Can be number from backend, boolean in JS
+    show_insentif: 0 | 1 | boolean;
+    user_confirmation: 0 | 1 | boolean;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface PeriodesIndexProps {
+    periodes: LaravelPaginatorProps<Periode>;
+    filters?: Record<string, string>; // For any filtering if implemented
+    flash?: {
+        success?: string;
+        error?: string;
+    };
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Admin\RubrikKategoriController;
 use App\Http\Controllers\Admin\RubrikRemunController;
 use App\Http\Controllers\Admin\UnitController;
 use App\Http\Controllers\Admin\UserController;
+use App\Http\Controllers\Admin\PeriodeController; // Added for Periode
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -47,6 +48,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::resource('rubrik-remun', RubrikRemunController::class)->except(['show', 'create', 'edit']); // Added RubrikRemun
         Route::resource('rubrik-kategori', RubrikKategoriController::class)->except(['show']); // Added RubrikKategori
         Route::resource('rubrik', RubrikController::class); // Added Rubrik
+
+        // Periode Management Routes
+        Route::resource('periodes', PeriodeController::class)->except(['show']);
+        Route::post('periodes/{periode}/activate', [PeriodeController::class, 'activate'])->name('periodes.activate');
+        Route::post('periodes/{periode}/deactivate', [PeriodeController::class, 'deactivate'])->name('periodes.deactivate');
     });
 
 });

--- a/tests/Feature/Admin/PeriodeControllerTest.php
+++ b/tests/Feature/Admin/PeriodeControllerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Periode;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class PeriodeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $adminUser;
+    protected User $regularUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create roles and permissions
+        $adminRole = Role::create(['name' => 'admin']);
+        $managePeriodesPermission = Permission::create(['name' => 'manage periodes']); // Example permission
+        $adminRole->givePermissionTo($managePeriodesPermission);
+
+        // Create admin user
+        $this->adminUser = User::factory()->create();
+        $this->adminUser->assignRole($adminRole);
+        $this->adminUser->last_active_role_id = $adminRole->id; // Assuming this field exists
+        $this->adminUser->save();
+
+
+        // Create regular user without admin permissions
+        $this->regularUser = User::factory()->create();
+
+        // Seed necessary base data if any (e.g. default roles from seeder)
+        // $this->seed(PermissionsSeeder::class); // If you have a seeder for permissions
+    }
+
+    private function getPeriodeData(array $overrides = []): array
+    {
+        return array_merge([
+            'nama' => 'Periode Test',
+            'tahun' => 2024,
+            'periode' => 1,
+            'keterangan' => 'Keterangan periode test',
+            'tgl_mulai' => '2024-01-01',
+            'tgl_selesai' => '2024-06-30',
+            'aktif' => 0, // Default to inactive, activation is a separate step
+        ], $overrides);
+    }
+
+    public function test_admin_can_access_periode_index_page()
+    {
+        $response = $this->actingAs($this->adminUser)->get(route('admin.periodes.index'));
+        $response->assertOk();
+        $response->assertInertia(fn ($assert) => $assert->component('Admin/Periodes/Index'));
+    }
+
+    public function test_admin_can_access_periode_create_page()
+    {
+        $response = $this->actingAs($this->adminUser)->get(route('admin.periodes.create'));
+        $response->assertOk();
+        $response->assertInertia(fn ($assert) => $assert->component('Admin/Periodes/Create'));
+    }
+
+    public function test_admin_can_store_new_periode()
+    {
+        $data = $this->getPeriodeData();
+        $response = $this->actingAs($this->adminUser)->post(route('admin.periodes.store'), $data);
+
+        $response->assertRedirect(route('admin.periodes.index'));
+        $response->assertSessionHas('success');
+        $this->assertDatabaseHas('periodes', ['nama' => $data['nama'], 'tahun' => $data['tahun']]);
+    }
+
+    public function test_store_periode_fails_with_invalid_data()
+    {
+        $data = $this->getPeriodeData(['nama' => '', 'tahun' => 'not-a-year']); // Invalid data
+        $response = $this->actingAs($this->adminUser)->post(route('admin.periodes.store'), $data);
+
+        $response->assertSessionHasErrors(['nama', 'tahun']);
+        $this->assertDatabaseMissing('periodes', ['periode' => $data['periode']]);
+    }
+
+    public function test_admin_can_access_periode_edit_page()
+    {
+        $periode = Periode::factory()->create();
+        $response = $this->actingAs($this->adminUser)->get(route('admin.periodes.edit', $periode->id));
+        $response->assertOk();
+        $response->assertInertia(fn ($assert) => $assert
+            ->component('Admin/Periodes/Edit')
+            ->has('periode.id', $periode->id)
+        );
+    }
+
+    public function test_admin_can_update_periode()
+    {
+        $periode = Periode::factory()->create();
+        $updatedData = $this->getPeriodeData(['nama' => 'Periode Updated Test', 'tahun' => 2025]);
+
+        $response = $this->actingAs($this->adminUser)->put(route('admin.periodes.update', $periode->id), $updatedData);
+
+        $response->assertRedirect(route('admin.periodes.index'));
+        $response->assertSessionHas('success');
+        $this->assertDatabaseHas('periodes', ['id' => $periode->id, 'nama' => $updatedData['nama'], 'tahun' => $updatedData['tahun']]);
+    }
+
+    public function test_update_periode_fails_with_invalid_data()
+    {
+        $periode = Periode::factory()->create();
+        $invalidData = $this->getPeriodeData(['nama' => '', 'tahun' => 'invalid-year']);
+
+        $response = $this->actingAs($this->adminUser)->put(route('admin.periodes.update', $periode->id), $invalidData);
+        $response->assertSessionHasErrors(['nama', 'tahun']);
+        $this->assertNotEquals('', $periode->fresh()->nama); // Check original name is not changed
+    }
+
+    public function test_admin_can_delete_inactive_periode()
+    {
+        $periode = Periode::factory()->create(['aktif' => 0]);
+        $response = $this->actingAs($this->adminUser)->delete(route('admin.periodes.destroy', $periode->id));
+
+        $response->assertRedirect(route('admin.periodes.index'));
+        $response->assertSessionHas('success');
+        $this->assertDatabaseMissing('periodes', ['id' => $periode->id]);
+    }
+
+    public function test_admin_cannot_delete_active_periode()
+    {
+        $periode = Periode::factory()->create(['aktif' => 1]);
+        $response = $this->actingAs($this->adminUser)->delete(route('admin.periodes.destroy', $periode->id));
+
+        $response->assertRedirect(route('admin.periodes.index'));
+        $response->assertSessionHas('error', 'Periode aktif tidak dapat dihapus.'); // Check for the specific error message
+        $this->assertDatabaseHas('periodes', ['id' => $periode->id]);
+    }
+
+    public function test_admin_can_activate_periode()
+    {
+        $periodeToActivate = Periode::factory()->create(['aktif' => 0]);
+        $currentlyActivePeriode = Periode::factory()->create(['aktif' => 1, 'nama' => 'Old Active Periode']);
+
+        $response = $this->actingAs($this->adminUser)->post(route('admin.periodes.activate', $periodeToActivate->id));
+
+        $response->assertRedirect(route('admin.periodes.index'));
+        $response->assertSessionHas('success');
+
+        $this->assertDatabaseHas('periodes', ['id' => $periodeToActivate->id, 'aktif' => 1]);
+        $this->assertDatabaseHas('periodes', ['id' => $currentlyActivePeriode->id, 'aktif' => 0]);
+    }
+
+    public function test_activating_already_active_periode_keeps_it_active_and_others_inactive()
+    {
+        $activePeriode = Periode::factory()->create(['aktif' => 1, 'nama' => 'Main Active Periode']);
+        $inactivePeriode1 = Periode::factory()->create(['aktif' => 0, 'nama' => 'Inactive 1']);
+
+        $response = $this->actingAs($this->adminUser)->post(route('admin.periodes.activate', $activePeriode->id));
+
+        $response->assertRedirect(route('admin.periodes.index'));
+        $response->assertSessionHas('success');
+        $this->assertEquals(1, $activePeriode->fresh()->aktif);
+        $this->assertEquals(0, $inactivePeriode1->fresh()->aktif);
+    }
+
+    public function test_admin_can_deactivate_periode()
+    {
+        $periodeToDeactivate = Periode::factory()->create(['aktif' => 1]);
+
+        $response = $this->actingAs($this->adminUser)->post(route('admin.periodes.deactivate', $periodeToDeactivate->id));
+
+        $response->assertRedirect(route('admin.periodes.index'));
+        $response->assertSessionHas('success');
+        $this->assertDatabaseHas('periodes', ['id' => $periodeToDeactivate->id, 'aktif' => 0]);
+    }
+
+    public function test_deactivating_already_inactive_periode_keeps_it_inactive()
+    {
+        $inactivePeriode = Periode::factory()->create(['aktif' => 0]);
+
+        $response = $this->actingAs($this->adminUser)->post(route('admin.periodes.deactivate', $inactivePeriode->id));
+        $response->assertRedirect(route('admin.periodes.index'));
+        $this->assertEquals(0, $inactivePeriode->fresh()->aktif);
+    }
+
+    public function test_unauthenticated_user_cannot_access_periode_pages()
+    {
+        $this->get(route('admin.periodes.index'))->assertRedirect(route('login'));
+        $this->get(route('admin.periodes.create'))->assertRedirect(route('login'));
+
+        $periode = Periode::factory()->create();
+        $this->get(route('admin.periodes.edit', $periode->id))->assertRedirect(route('login'));
+        $this->post(route('admin.periodes.store'), [])->assertRedirect(route('login'));
+        $this->put(route('admin.periodes.update', $periode->id), [])->assertRedirect(route('login'));
+        $this->delete(route('admin.periodes.destroy', $periode->id))->assertRedirect(route('login'));
+        $this->post(route('admin.periodes.activate', $periode->id))->assertRedirect(route('login'));
+        $this->post(route('admin.periodes.deactivate', $periode->id))->assertRedirect(route('login'));
+    }
+
+    // Optional: Test authorization if specific permissions are used beyond basic auth + admin role
+    // For example, if a 'view periodes' permission was required.
+    // public function test_user_without_permission_cannot_access_periode_index()
+    // {
+    //     $this->actingAs($this->regularUser)->get(route('admin.periodes.index'))->assertStatus(403);
+    // }
+
+}


### PR DESCRIPTION
Implements full CRUD functionality for Periodes, including activation and deactivation.

- Adds Periode model fillable attributes.
- Implements PeriodeController with index, create, store, edit, update, destroy, activate, and deactivate methods.
- Defines web routes for periode management.
- Creates React components (Index, Create, Edit, PeriodeForm) using InertiaJS and shadcn for the frontend.
- Updates admin navigation to include a link to Periode management.
- Adds PHPUnit feature tests for the PeriodeController.