### PR TITLE
feat: Implement CRUD for PegawaiJabatan on Pegawai detail page

### DIFF
--- a/app/Http/Controllers/Admin/PegawaiController.php
+++ b/app/Http/Controllers/Admin/PegawaiController.php
@@ -7,6 +7,7 @@ use App\Models\Pegawai;
 use App\Models\PegawaiJenis;
 use App\Http\Requests\Admin\StorePegawaiRequest;
 use App\Http\Requests\Admin\UpdatePegawaiRequest;
+use App\Models\JabatanUnit;
 use Illuminate\Http\Request; // Keep for index if not type hinted specifically
 use Illuminate\Support\Facades\Storage; // For file handling
 use Inertia\Inertia;
@@ -57,8 +58,17 @@ class PegawaiController extends Controller
 
     public function show(Pegawai $pegawai)
     {
-        $pegawai->load('pegawaiJenis');
-        return Inertia::render('Admin/Pegawai/Show', ['pegawai' => $pegawai]);
+        $pegawai->load(
+            'pegawaiJenis',
+            'pegawaiJabatans.jabatanUnit.jabatan',
+            'pegawaiJabatans.jabatanUnit.unit'
+        );
+        $jabatanUnits = JabatanUnit::with(['jabatan', 'unit'])->orderBy('nama')->get();
+
+        return Inertia::render('Admin/Pegawai/Show', [
+            'pegawai' => $pegawai,
+            'jabatanUnits' => $jabatanUnits,
+        ]);
     }
 
     public function edit(Pegawai $pegawai)

--- a/app/Http/Controllers/Admin/PegawaiJabatanController.php
+++ b/app/Http/Controllers/Admin/PegawaiJabatanController.php
@@ -3,8 +3,59 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Pegawai;
+use App\Models\PegawaiJabatan;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
 
 class PegawaiJabatanController extends Controller
 {
-    //
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request, Pegawai $pegawai)
+    {
+        $validated = $request->validate([
+            'jabatan_unit_id' => 'required|exists:jabatan_units,id',
+            'tmt' => 'required|date',
+            'selesai' => 'nullable|date|after_or_equal:tmt',
+        ]);
+
+        // Ensure pegawai_id is set from the route model binding
+        $validated['pegawai_id'] = $pegawai->id;
+
+        PegawaiJabatan::create($validated);
+
+        return Redirect::route('admin.pegawai.show', $pegawai->id)
+            ->with('success', 'Riwayat jabatan berhasil ditambahkan.');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, PegawaiJabatan $pegawaiJabatan)
+    {
+        $validated = $request->validate([
+            'jabatan_unit_id' => 'required|exists:jabatan_units,id',
+            'tmt' => 'required|date',
+            'selesai' => 'nullable|date|after_or_equal:tmt',
+        ]);
+
+        $pegawaiJabatan->update($validated);
+
+        return Redirect::route('admin.pegawai.show', $pegawaiJabatan->pegawai_id)
+            ->with('success', 'Riwayat jabatan berhasil diperbarui.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(PegawaiJabatan $pegawaiJabatan)
+    {
+        $pegawaiId = $pegawaiJabatan->pegawai_id;
+        $pegawaiJabatan->delete();
+
+        return Redirect::route('admin.pegawai.show', $pegawaiId)
+            ->with('success', 'Riwayat jabatan berhasil dihapus.');
+    }
 }

--- a/app/Models/JabatanUnit.php
+++ b/app/Models/JabatanUnit.php
@@ -4,9 +4,47 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class JabatanUnit extends Model
 {
     /** @use HasFactory<\Database\Factories\JabatanUnitFactory> */
     use HasFactory;
+
+    protected $fillable = [
+        'nama',
+        'jabatan_id',
+        'unit_id',
+    ];
+
+    /**
+     * Get the jabatan that owns the JabatanUnit
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function jabatan(): BelongsTo
+    {
+        return $this->belongsTo(Jabatan::class);
+    }
+
+    /**
+     * Get the unit that owns the JabatanUnit
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function unit(): BelongsTo
+    {
+        return $this->belongsTo(Unit::class);
+    }
+
+    /**
+     * Get all of the pegawaiJabatans for the JabatanUnit
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function pegawaiJabatans(): HasMany
+    {
+        return $this->hasMany(PegawaiJabatan::class);
+    }
 }

--- a/app/Models/Pegawai.php
+++ b/app/Models/Pegawai.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Pegawai extends Model
 {
@@ -35,5 +36,15 @@ class Pegawai extends Model
     public function pegawaiJenis()
     {
         return $this->belongsTo(PegawaiJenis::class);
+    }
+
+    /**
+     * Get all of the pegawaiJabatans for the Pegawai
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function pegawaiJabatans(): HasMany
+    {
+        return $this->hasMany(PegawaiJabatan::class);
     }
 }

--- a/app/Models/PegawaiJabatan.php
+++ b/app/Models/PegawaiJabatan.php
@@ -4,9 +4,42 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PegawaiJabatan extends Model
 {
     /** @use HasFactory<\Database\Factories\PegawaiJabatanFactory> */
     use HasFactory;
+
+    protected $fillable = [
+        'pegawai_id',
+        'jabatan_unit_id',
+        'tmt',
+        'selesai',
+    ];
+
+    protected $casts = [
+        'tmt' => 'date',
+        'selesai' => 'date',
+    ];
+
+    /**
+     * Get the pegawai that owns the PegawaiJabatan
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function pegawai(): BelongsTo
+    {
+        return $this->belongsTo(Pegawai::class);
+    }
+
+    /**
+     * Get the jabatanUnit that owns the PegawaiJabatan
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function jabatanUnit(): BelongsTo
+    {
+        return $this->belongsTo(JabatanUnit::class);
+    }
 }

--- a/resources/js/pages/Admin/Pegawai/Partials/PegawaiJabatanForm.tsx
+++ b/resources/js/pages/Admin/Pegawai/Partials/PegawaiJabatanForm.tsx
@@ -1,0 +1,170 @@
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { InputError } from '@/components/ui/input-error'; // Assuming this is your InputError component
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { JabatanUnit, PegawaiJabatan } from '@/types';
+import { cn } from '@/lib/utils';
+import { useForm } from '@inertiajs/react';
+import { CalendarIcon } from 'lucide-react';
+import { FormEventHandler, useEffect } from 'react';
+import { format, parseISO } from 'date-fns';
+
+interface PegawaiJabatanFormProps {
+    pegawaiId: number;
+    jabatanUnits: JabatanUnit[];
+    pegawaiJabatan?: PegawaiJabatan; // For editing
+    onSuccess?: () => void;
+    onCancel: () => void;
+    submitButtonText?: string;
+}
+
+type FormData = {
+    jabatan_unit_id: string; // Keep as string for form state
+    tmt: Date | undefined;
+    selesai: Date | undefined;
+};
+
+export default function PegawaiJabatanForm({
+    pegawaiId,
+    jabatanUnits,
+    pegawaiJabatan,
+    onSuccess,
+    onCancel,
+    submitButtonText = 'Simpan',
+}: PegawaiJabatanFormProps) {
+    const { data, setData, post, put, processing, errors, reset } = useForm<FormData>({
+        jabatan_unit_id: pegawaiJabatan?.jabatan_unit_id?.toString() || '',
+        tmt: pegawaiJabatan?.tmt ? parseISO(pegawaiJabatan.tmt) : undefined,
+        selesai: pegawaiJabatan?.selesai ? parseISO(pegawaiJabatan.selesai) : undefined,
+    });
+
+    useEffect(() => {
+        if (pegawaiJabatan) {
+            setData({
+                jabatan_unit_id: pegawaiJabatan.jabatan_unit_id?.toString() || '',
+                tmt: pegawaiJabatan.tmt ? parseISO(pegawaiJabatan.tmt) : undefined,
+                selesai: pegawaiJabatan.selesai ? parseISO(pegawaiJabatan.selesai) : undefined,
+            });
+        } else {
+            reset();
+        }
+    }, [pegawaiJabatan]);
+
+    const handleSubmit: FormEventHandler = (e) => {
+        e.preventDefault();
+        const formattedData = {
+            ...data,
+            tmt: data.tmt ? format(data.tmt, 'yyyy-MM-dd') : null,
+            selesai: data.selesai ? format(data.selesai, 'yyyy-MM-dd') : null,
+        };
+
+        if (pegawaiJabatan) {
+            put(route('admin.pegawai-jabatan.update', pegawaiJabatan.id), {
+                data: formattedData,
+                onSuccess: () => {
+                    reset();
+                    onSuccess?.();
+                },
+                preserveScroll: true,
+            });
+        } else {
+            post(route('admin.pegawai.pegawai-jabatan.store', pegawaiId), {
+                data: formattedData,
+                onSuccess: () => {
+                    reset();
+                    onSuccess?.();
+                },
+                preserveScroll: true,
+            });
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className='space-y-4'>
+            <div>
+                <Label htmlFor='jabatan_unit_id'>Jabatan Unit</Label>
+                <Select
+                    value={data.jabatan_unit_id}
+                    onValueChange={(value) => setData('jabatan_unit_id', value)}
+                >
+                    <SelectTrigger id='jabatan_unit_id'>
+                        <SelectValue placeholder='Pilih Jabatan Unit' />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {jabatanUnits.map((ju) => (
+                            <SelectItem key={ju.id} value={ju.id.toString()}>
+                                {ju.nama} ({ju.jabatan?.nama} - {ju.unit?.nama})
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+                <InputError message={errors.jabatan_unit_id} className='mt-2' />
+            </div>
+
+            <div>
+                <Label htmlFor='tmt'>Tanggal Mulai Tugas (TMT)</Label>
+                <Popover>
+                    <PopoverTrigger asChild>
+                        <Button
+                            variant={'outline'}
+                            className={cn(
+                                'w-full justify-start text-left font-normal',
+                                !data.tmt && 'text-muted-foreground',
+                            )}
+                        >
+                            <CalendarIcon className='mr-2 h-4 w-4' />
+                            {data.tmt ? format(data.tmt, 'PPP') : <span>Pilih tanggal</span>}
+                        </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className='w-auto p-0'>
+                        <Calendar
+                            mode='single'
+                            selected={data.tmt}
+                            onSelect={(date) => setData('tmt', date)}
+                            initialFocus
+                        />
+                    </PopoverContent>
+                </Popover>
+                <InputError message={errors.tmt} className='mt-2' />
+            </div>
+
+            <div>
+                <Label htmlFor='selesai'>Tanggal Selesai (Opsional)</Label>
+                <Popover>
+                    <PopoverTrigger asChild>
+                        <Button
+                            variant={'outline'}
+                            className={cn(
+                                'w-full justify-start text-left font-normal',
+                                !data.selesai && 'text-muted-foreground',
+                            )}
+                        >
+                            <CalendarIcon className='mr-2 h-4 w-4' />
+                            {data.selesai ? format(data.selesai, 'PPP') : <span>Pilih tanggal</span>}
+                        </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className='w-auto p-0'>
+                        <Calendar
+                            mode='single'
+                            selected={data.selesai}
+                            onSelect={(date) => setData('selesai', date)}
+                            initialFocus
+                        />
+                    </PopoverContent>
+                </Popover>
+                <InputError message={errors.selesai} className='mt-2' />
+            </div>
+
+            <div className='flex justify-end space-x-2'>
+                <Button type='button' variant='outline' onClick={onCancel} disabled={processing}>
+                    Batal
+                </Button>
+                <Button type='submit' disabled={processing}>
+                    {processing ? 'Menyimpan...' : submitButtonText}
+                </Button>
+            </div>
+        </form>
+    );
+}

--- a/resources/js/pages/Admin/Pegawai/Show.tsx
+++ b/resources/js/pages/Admin/Pegawai/Show.tsx
@@ -1,16 +1,85 @@
 import AppLayout from '@/layouts/app-layout';
-import { Head, Link } from '@inertiajs/react';
-import { PageProps, Pegawai } from '@/types';
+import { Head, Link, router, usePage } from '@inertiajs/react';
+import { JabatanUnit, PageProps, Pegawai, PegawaiJabatan } from '@/types';
 import Heading from '@/components/heading';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ArrowLeft } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ArrowLeft, Edit2, PlusCircle, Trash2 } from 'lucide-react';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+    DialogFooter,
+    DialogClose,
+} from '@/components/ui/dialog'; // Assuming Dialog component exists
+import { useState } from 'react';
+import PegawaiJabatanForm from './Partials/PegawaiJabatanForm';
+import { format, parseISO } from 'date-fns';
+import { id as localeID } from 'date-fns/locale'; // For Indonesian date formatting
 
 interface ShowPageProps extends PageProps {
     pegawai: Pegawai;
+    jabatanUnits: JabatanUnit[];
+    flash: {
+        success?: string;
+        error?: string;
+    };
 }
 
-export default function Show({ auth, pegawai }: ShowPageProps) {
+export default function Show({ auth, pegawai: initialPegawai, jabatanUnits, flash }: ShowPageProps) {
+    const { pegawai } = usePage<ShowPageProps>().props; // Ensures we have the latest pegawai data after form submissions
+
+    const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+    const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+    const [selectedPegawaiJabatan, setSelectedPegawaiJabatan] = useState<PegawaiJabatan | undefined>(undefined);
+
+    const openAddModal = () => {
+        setSelectedPegawaiJabatan(undefined);
+        setIsAddModalOpen(true);
+    };
+
+    const openEditModal = (pj: PegawaiJabatan) => {
+        setSelectedPegawaiJabatan(pj);
+        setIsEditModalOpen(true);
+    };
+
+    const openDeleteConfirm = (pj: PegawaiJabatan) => {
+        setSelectedPegawaiJabatan(pj);
+        setIsDeleteConfirmOpen(true);
+    };
+
+    const handleDelete = () => {
+        if (selectedPegawaiJabatan) {
+            router.delete(route('admin.pegawai-jabatan.destroy', selectedPegawaiJabatan.id), {
+                preserveScroll: true,
+                onSuccess: () => setIsDeleteConfirmOpen(false),
+            });
+        }
+    };
+
+    const formatDate = (dateString?: string | null) => {
+        if (!dateString) return '-';
+        try {
+            return format(parseISO(dateString), 'dd MMMM yyyy', { locale: localeID });
+        } catch (error) {
+            console.error("Error formatting date:", dateString, error);
+            return dateString; // fallback to original string if parsing fails
+        }
+    };
+
+
     return (
         <AppLayout
             user={auth.user}
@@ -20,13 +89,25 @@ export default function Show({ auth, pegawai }: ShowPageProps) {
                     <Button variant='outline' asChild>
                         <Link href={route('admin.pegawai.index')}>
                             <ArrowLeft className='mr-2 h-4 w-4' />
-                            Back to List
+                            Kembali ke Daftar
                         </Link>
                     </Button>
                 </div>
             }
         >
             <Head title={`Detail Pegawai - ${pegawai.nama}`} />
+
+            {flash?.success && (
+                 <div className="mb-4 rounded bg-green-100 p-4 text-sm text-green-700">
+                    {flash.success}
+                </div>
+            )}
+            {flash?.error && (
+                <div className="mb-4 rounded bg-red-100 p-4 text-sm text-red-700">
+                    {flash.error}
+                </div>
+            )}
+
 
             <div className='space-y-6'>
                 <Card>
@@ -71,7 +152,7 @@ export default function Show({ auth, pegawai }: ShowPageProps) {
                             </div>
                             <div>
                                 <p className='text-sm font-medium text-muted-foreground'>Tanggal Lahir</p>
-                                <p>{pegawai.tanggal_lahir || '-'}</p>
+                                <p>{formatDate(pegawai.tanggal_lahir)}</p>
                             </div>
                             <div>
                                 <p className='text-sm font-medium text-muted-foreground'>Jenis Kelamin</p>
@@ -103,12 +184,141 @@ export default function Show({ auth, pegawai }: ShowPageProps) {
                     </CardContent>
                 </Card>
 
-                {/* TODO: Add sections for Jabatan, Fungsional, etc. if relationships are implemented */}
+                {/* Riwayat Jabatan Section */}
+                <Card>
+                    <CardHeader className='flex flex-row items-center justify-between'>
+                        <div>
+                            <CardTitle>Riwayat Jabatan</CardTitle>
+                            <CardDescription>Daftar jabatan yang pernah diemban oleh pegawai.</CardDescription>
+                        </div>
+                        <Dialog open={isAddModalOpen} onOpenChange={setIsAddModalOpen}>
+                            <DialogTrigger asChild>
+                                <Button onClick={openAddModal}>
+                                    <PlusCircle className='mr-2 h-4 w-4' />
+                                    Tambah Riwayat
+                                </Button>
+                            </DialogTrigger>
+                            <DialogContent className='sm:max-w-2xl'>
+                                <DialogHeader>
+                                    <DialogTitle>Tambah Riwayat Jabatan</DialogTitle>
+                                    <DialogDescription>
+                                        Isi detail jabatan baru untuk pegawai {pegawai.nama}.
+                                    </DialogDescription>
+                                </DialogHeader>
+                                <PegawaiJabatanForm
+                                    pegawaiId={pegawai.id}
+                                    jabatanUnits={jabatanUnits}
+                                    onSuccess={() => setIsAddModalOpen(false)}
+                                    onCancel={() => setIsAddModalOpen(false)}
+                                    submitButtonText='Tambah Jabatan'
+                                />
+                            </DialogContent>
+                        </Dialog>
+                    </CardHeader>
+                    <CardContent>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Jabatan Unit</TableHead>
+                                    <TableHead>Jabatan</TableHead>
+                                    <TableHead>Unit</TableHead>
+                                    <TableHead>TMT</TableHead>
+                                    <TableHead>Selesai</TableHead>
+                                    <TableHead className='text-right'>Aksi</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {pegawai.pegawai_jabatans && pegawai.pegawai_jabatans.length > 0 ? (
+                                    pegawai.pegawai_jabatans.map((pj) => (
+                                        <TableRow key={pj.id}>
+                                            <TableCell>{pj.jabatan_unit?.nama}</TableCell>
+                                            <TableCell>{pj.jabatan_unit?.jabatan?.nama || '-'}</TableCell>
+                                            <TableCell>{pj.jabatan_unit?.unit?.nama || '-'}</TableCell>
+                                            <TableCell>{formatDate(pj.tmt)}</TableCell>
+                                            <TableCell>{formatDate(pj.selesai)}</TableCell>
+                                            <TableCell className='text-right'>
+                                                <Button
+                                                    variant='ghost'
+                                                    size='sm'
+                                                    onClick={() => openEditModal(pj)}
+                                                    className='mr-1'
+                                                >
+                                                    <Edit2 className='h-4 w-4' />
+                                                </Button>
+                                                <Button
+                                                    variant='ghost'
+                                                    size='sm'
+                                                    onClick={() => openDeleteConfirm(pj)}
+                                                    className='text-red-500 hover:text-red-700'
+                                                >
+                                                    <Trash2 className='h-4 w-4' />
+                                                </Button>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))
+                                ) : (
+                                    <TableRow>
+                                        <TableCell colSpan={6} className='text-center'>
+                                            Belum ada riwayat jabatan.
+                                        </TableCell>
+                                    </TableRow>
+                                )}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
 
-                <div className='text-right'>
+                {/* Edit PegawaiJabatan Modal */}
+                <Dialog open={isEditModalOpen} onOpenChange={setIsEditModalOpen}>
+                    <DialogContent className='sm:max-w-2xl'>
+                        <DialogHeader>
+                            <DialogTitle>Edit Riwayat Jabatan</DialogTitle>
+                            <DialogDescription>
+                                Perbarui detail jabatan untuk {pegawai.nama}.
+                            </DialogDescription>
+                        </DialogHeader>
+                        {selectedPegawaiJabatan && (
+                             <PegawaiJabatanForm
+                                pegawaiId={pegawai.id}
+                                jabatanUnits={jabatanUnits}
+                                pegawaiJabatan={selectedPegawaiJabatan}
+                                onSuccess={() => setIsEditModalOpen(false)}
+                                onCancel={() => setIsEditModalOpen(false)}
+                                submitButtonText='Simpan Perubahan'
+                            />
+                        )}
+                    </DialogContent>
+                </Dialog>
+
+                {/* Delete Confirmation Dialog */}
+                <Dialog open={isDeleteConfirmOpen} onOpenChange={setIsDeleteConfirmOpen}>
+                    <DialogContent>
+                        <DialogHeader>
+                            <DialogTitle>Konfirmasi Hapus</DialogTitle>
+                            <DialogDescription>
+                                Apakah Anda yakin ingin menghapus riwayat jabatan ini? Tindakan ini tidak dapat diurungkan.
+                                <br />
+                                Jabatan: {selectedPegawaiJabatan?.jabatan_unit?.jabatan?.nama} di Unit: {selectedPegawaiJabatan?.jabatan_unit?.unit?.nama}
+                                <br />
+                                TMT: {formatDate(selectedPegawaiJabatan?.tmt)}
+                            </DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                            <DialogClose asChild>
+                                <Button variant="outline" onClick={() => setIsDeleteConfirmOpen(false)}>Batal</Button>
+                            </DialogClose>
+                            <Button variant="destructive" onClick={handleDelete}>
+                                Ya, Hapus
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                </Dialog>
+
+
+                <div className='mt-6 text-right'>
                     <Button asChild>
                         <Link href={route('admin.pegawai.edit', pegawai.id)}>
-                            Edit Pegawai
+                            Edit Data Pegawai
                         </Link>
                     </Button>
                 </div>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -118,6 +118,44 @@ export interface Pegawai {
     created_at: string;
     updated_at: string;
     pegawai_jenis?: PegawaiJenis; // For eager loading
+    pegawai_jabatans?: PegawaiJabatan[]; // Added for PegawaiJabatan
+}
+
+// Added for Jabatan
+export interface Jabatan {
+    id: number;
+    nama: string;
+    grade?: number | null;
+    job_value?: number | null;
+    cg: boolean;
+    poin_skp?: number | null;
+    active: boolean;
+    created_at?: string;
+    updated_at?: string;
+}
+
+// Added for JabatanUnit
+export interface JabatanUnit {
+    id: number;
+    nama: string;
+    jabatan_id: number;
+    unit_id: string; // Assuming Unit ID is string (UUID)
+    jabatan?: Jabatan; // For eager loading
+    unit?: Unit; // For eager loading
+    created_at?: string;
+    updated_at?: string;
+}
+
+// Added for PegawaiJabatan
+export interface PegawaiJabatan {
+    id: number;
+    pegawai_id: number;
+    jabatan_unit_id: number;
+    tmt: string; // Dates are typically strings from backend, parse if needed
+    selesai?: string | null;
+    jabatan_unit?: JabatanUnit; // For eager loading
+    created_at?: string;
+    updated_at?: string;
 }
 
 export type Fungsional = {

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Admin\RubrikRemunController;
 use App\Http\Controllers\Admin\UnitController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Admin\PeriodeController; // Added for Periode
+use App\Http\Controllers\Admin\PegawaiJabatanController; // Added for PegawaiJabatan
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -39,7 +40,15 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::name('admin.')->prefix('admin')->group(function () {
         Route::resource('roles', RoleController::class)->except(['show']);
         Route::get('permissions', [PermissionController::class, 'index'])->name('permissions.index');
-        Route::resource('pegawai', PegawaiController::class); // Added
+        Route::resource('pegawai', PegawaiController::class);
+        Route::resource('pegawai.pegawai-jabatan', PegawaiJabatanController::class)
+            ->except(['index', 'show', 'edit', 'create'])
+            ->shallow()
+            ->names([
+                'store' => 'pegawai.pegawai-jabatan.store',
+                'update' => 'pegawai.pegawai-jabatan.update', // Explicitly naming to avoid conflict if any
+                'destroy' => 'pegawai.pegawai-jabatan.destroy',
+            ]);
         Route::resource('units', UnitController::class)->except(['show', 'create', 'edit']);
         Route::resource('fungsionals', FungsionalController::class)->except(['show', 'create', 'edit']); // Added
         Route::resource('pegawai-ikatan', PegawaiIkatanController::class)->except(['show', 'create', 'edit']); // Added


### PR DESCRIPTION
Implements the ability to display, add, edit, and delete PegawaiJabatan records directly from the Pegawai detail page.

Backend:
- Updated Pegawai, PegawaiJabatan, and JabatanUnit models with necessary relationships and fillable attributes.
- Modified PegawaiController to load PegawaiJabatan data and related JabatanUnit information for the show page.
- Created PegawaiJabatanController to handle store, update, and destroy actions.
- Added nested resource routes for PegawaiJabatan.

Frontend:
- Updated TypeScript definitions for new/modified models.
- Created PegawaiJabatanForm component for add/edit operations.
- Modified Pegawai show page (Show.tsx) to:
  - Display a table of PegawaiJabatan records.
  - Include buttons for adding, editing, and deleting records.
  - Utilize dialogs for create/edit forms and delete confirmation.
  - Integrate PegawaiJabatanForm.
  - Handle flash messages for success/error feedback.